### PR TITLE
Add Dockerfile for devops support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:latest
+
+RUN apt update \
+  && apt install -y curl git vim gnupg python3.8 python3.8-distutils\
+  && cd /usr/local/bin \
+  && ln -s /usr/bin/python3.8 python
+
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+  && python get-pip.py \
+  && rm get-pip.py
+
+RUN pip install numpy notebook matplotlib
+
+RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
+RUN mv bazel.gpg /etc/apt/trusted.gpg.d/
+RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+
+RUN apt update \
+  && apt install -y bazel
+
+CMD /bin/bash

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,0 +1,1 @@
+docker run -v `pwd`:/nn -p 8888:8888 --rm -it fzxu/nn /bin/bash


### PR DESCRIPTION
- Add Dockerfile, which build to a docker image [fzxu/nn](https://hub.docker.com/repository/docker/fzxu/nn) that contains the dev environment.
- Add docker_run.sh to start up the dev container with dir mount and port mapping etc.