### PR TITLE
[Dockerfile] Add WORKDIR and mount bazel cache dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,6 @@ RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.
 RUN apt update \
   && apt install -y bazel
 
+WORKDIR /nn
+
 CMD /bin/bash

--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ This project has a docker image [fzxu/nn](https://hub.docker.com/repository/dock
 
 - (Prerequisite: docker should be installed) Run the `docker_run.sh` script in the root directory. Docker will pull the image from docker hub if it's your first time, which might take a while depending on your network.
     ```shell
-    # docker run -v `pwd`:/nn -p 8888:8888 --rm -it fzxu/nn /bin/bash
+    # docker run \
+    #     -v `pwd`:/nn \
+    #     -v `pwd`/bazel-cache:/root/.cache/bazel \
+    #     -p 8888:8888 \
+    #     --rm -it fzxu/nn /bin/bash
     ./docker_run.sh
     ```
-    - This docker run command mount the repo dir into the container and mapped 8888 port for jupyter notebook usesage.
-- Once the container is started, cd to `/nn` which is the mounting point of your repo dir. Now you can mess around with code, and use bazel:
+    - This docker run command mount the repo dir and the bazel cache dir into the container, and also mapped 8888 port for jupyter notebook usesage.
+- Once the container is started, you will be in `/nn` directory which is the mounting point of your repo dir. Now you can mess around with code, and use bazel:
     - To simply build the source code (which is usually not needed as there's no binary/executables in it)
     ```shell
     bazel build //src:nn_src

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,1 +1,5 @@
-docker run -v `pwd`:/nn -p 8888:8888 --rm -it fzxu/nn /bin/bash
+docker run \
+    -v `pwd`:/nn \
+    -v `pwd`/bazel-cache:/root/.cache/bazel \
+    -p 8888:8888 \
+    --rm -it fzxu/nn /bin/bash


### PR DESCRIPTION
This PR did 2 things:
- Add `/nn` as WORKDIR so that each time you start the docker for developing you'll be in `/nn` dir automatically
- Bazel will need to download 700+Mb dependencies to run bazel build/test from a fresh bazel environment which will happen each time you start a new container. To solve this, this PR mounts a directory from host (`./bazel-cache` git ignored) into the bazel cache directory in the container (`/root/.cache/bazel`), which will preserve any bazel run-time dependencies in the host after download, so that they won't need to be downloaded again next time.