### PR TITLE
Refactor to adopt operators and computation graph

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -9,6 +9,8 @@ py_binary(
     deps = [
         "//src/operator:activation",
         "//src/operator:common",
+        "//src/operator:loss",
+        "//src/operator:normalizer",
         "//src/operator:operator",
         "//src:nn_src",
         "//data/MNIST:mnist_csv_loader"

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -7,6 +7,9 @@ py_binary(
         "jupyter.py",
     ],
     deps = [
+        "//src/operator:activation",
+        "//src/operator:common",
+        "//src/operator:operator",
         "//src:nn_src",
         "//data/MNIST:mnist_csv_loader"
     ],

--- a/src/BUILD
+++ b/src/BUILD
@@ -9,6 +9,12 @@ py_library(
         "layer.py",
         "model.py",
         "utils.py",
-        "operator.py",
     ],
+)
+
+py_library(
+    name = "utils",
+    srcs = [
+        "utils.py"
+    ]
 )

--- a/src/BUILD
+++ b/src/BUILD
@@ -15,6 +15,6 @@ py_library(
 py_library(
     name = "utils",
     srcs = [
-        "utils.py"
-    ]
+        "utils.py",
+    ],
 )

--- a/src/BUILD
+++ b/src/BUILD
@@ -9,5 +9,6 @@ py_library(
         "layer.py",
         "model.py",
         "utils.py",
+        "operator.py",
     ],
 )

--- a/src/cost.py
+++ b/src/cost.py
@@ -15,6 +15,7 @@ class MSE(Cost):
     def grad(cls, y_prime: np.ndarray, y: np.ndarray) -> np.ndarray:
         return 2 * (y_prime - y)
 
+
 class LogSoftmax(Cost):
 
     @classmethod
@@ -24,6 +25,7 @@ class LogSoftmax(Cost):
     @classmethod
     def grad(cls, y_prime: np.ndarray, y: np.ndarray) -> np.ndarray:
         return -(y == 1).astype('float') + np.exp(y_prime) / np.exp(y_prime).sum(axis=1)[:, np.newaxis]
+
 
 class CrossEntropyWithSoftmax(Cost):
     '''

--- a/src/model.py
+++ b/src/model.py
@@ -27,17 +27,17 @@ class Model:
         return self
 
     def inference(self, _input: np.ndarray) -> np.ndarray:
-        check_shape(_input, (None, self._input_dim), axis=1)
+        check_shape(_input.shape, (None, self._input_dim), axis=1)
         self._layers[0].a = _input
         self._layers[0].forward_pass()
         return self._layers[-1].a
 
     def get_cost(self, ground_truth: np.ndarray) -> float:
-        check_shape(self._layers[-1].a, ground_truth.shape)
+        check_shape(self._layers[-1].a.shape, ground_truth.shape)
         return self._cost.eval(self._layers[-1].a, ground_truth)
 
     def back_prop(self, ground_truth: np.ndarray):
-        check_shape(self._layers[-1].a, ground_truth.shape)
+        check_shape(self._layers[-1].a.shape, ground_truth.shape)
         y_grad = self._cost.grad(self._layers[-1].a, ground_truth)
         self._layers[-1].back_prop(y_grad)
 
@@ -50,14 +50,14 @@ class Model:
               epochs: int = 10,
               get_accuracy: Callable[[np.ndarray, np.ndarray], float] = None):
         # check input dimension etc. and initialize parameters
-        check_shape(train_set[0], (None, self._input_dim), axis=1)
-        check_shape(train_set[1], (None, self._output_dim), axis=1)
-        check_shape(test_set[0], (None, self._input_dim), axis=1)
-        check_shape(test_set[1], (None, self._output_dim), axis=1)
+        check_shape(train_set[0].shape, (None, self._input_dim), axis=1)
+        check_shape(train_set[1].shape, (None, self._output_dim), axis=1)
+        check_shape(test_set[0].shape, (None, self._input_dim), axis=1)
+        check_shape(test_set[1].shape, (None, self._output_dim), axis=1)
         if not validation_set:
             validation_set = test_set
-        check_shape(validation_set[0], (None, self._input_dim), axis=1)
-        check_shape(validation_set[1], (None, self._output_dim), axis=1)
+        check_shape(validation_set[0].shape, (None, self._input_dim), axis=1)
+        check_shape(validation_set[1].shape, (None, self._output_dim), axis=1)
         if learning_rate is not None:
             self._rate = learning_rate
         if not get_accuracy:

--- a/src/operator.py
+++ b/src/operator.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from typing import List
+
+
+class Operator:
+
+    def __init__(self):
+        self.preds, self.succs= [], []
+        self.forward_pass_count, self.back_prod_count = 0, 0
+
+    def _forward_pass(self):
+        raise NotImplemented('forward_pass')
+
+    def _back_prop(self) -> np.ndarray:
+        raise NotImplemented('back_prop')
+
+    def forward_pass(self):
+        self.forward_pass_count += 1
+        if self.forward_pass_count == len(self.preds):
+            self._forward_pass()
+            self.forward_pass_count = 0
+
+    def back_prop(self):
+        self.back_prod_count += 1
+        if self.back_prod_count == len(self.succs):
+            self._back_prop()
+            self.back_prod_count = 0

--- a/src/operator.py
+++ b/src/operator.py
@@ -1,19 +1,25 @@
 import numpy as np
 
-from typing import List
+from typing import List, Tuple
+from src.utils import check_shape
 
 
 class Operator:
 
-    def __init__(self):
+    def __init__(self, ishape: List[int], oshape: List[int]):
+        self.ishape, self.oshape = tuple(ishape), tuple(oshape)
         self.preds, self.succs= [], []
         self.forward_pass_count, self.back_prod_count = 0, 0
 
     def _forward_pass(self):
-        raise NotImplemented('forward_pass')
+        # override in subclass with this as callback
+        for succ in self.succs:
+            succ.forward_pass()
 
-    def _back_prop(self) -> np.ndarray:
-        raise NotImplemented('back_prop')
+    def _back_prop(self):
+        # override in subclass with this as callback
+        for pred in self.preds:
+            pred.back_prop()
 
     def forward_pass(self):
         self.forward_pass_count += 1
@@ -26,3 +32,39 @@ class Operator:
         if self.back_prod_count == len(self.succs):
             self._back_prop()
             self.back_prod_count = 0
+
+    def register(self, pred: 'Operator'):
+        self.preds.append(pred)
+        pred.succs.append(self)
+
+
+class ParameterizedOperator(Operator):
+
+    rate = 0.001
+
+    def __init__(self, ishape: List[int], oshape: List[int], rate: float = None):
+        super().__init__(ishape, oshape)
+        self._rate = rate if rate is not None else self.__class__.rate
+
+
+class MatMul(ParameterizedOperator):
+    
+    def __init__(self, ishape: List[int], oshape: List[int]):
+        super().__init__(ishape, oshape)
+        # weights initialized to [-0.1, 0.1]
+        self._w = np.random.random((ishape[0], oshape[0])) / 5. - .1
+
+    def register(self, pred: 'Operator'):
+        check_shape(pred.oshape, self.ishape)
+        super().register(pred)
+
+    def _forward_pass(self):
+        self.output = np.matmul(self.preds[0].output, self._w)
+        super()._forward_pass()
+
+    def _back_prop(self):
+        dL_do = np.sum(np.array([succ.grad for succ in self.succs]))
+        dL_dw = np.einsum('ki,kj', self.preds[0].output, dL_do)
+        self._w -= self._rate * dL_dw
+        self.grad = np.einsum('ik,jk', dL_do, self._w)
+        super()._back_prop()

--- a/src/operator/BUILD
+++ b/src/operator/BUILD
@@ -16,7 +16,7 @@ py_library(
     deps = [
         ":operator",
         "//src:utils",
-    ]
+    ],
 )
 
 py_library(
@@ -26,5 +26,26 @@ py_library(
     ],
     deps = [
         ":operator"
-    ]
+    ],
+)
+
+py_library(
+    name = "normalizer",
+    srcs = [
+        "normalizer.py",
+    ],
+    deps = [
+        ":operator",
+    ],
+)
+
+py_library(
+    name = "loss",
+    srcs = [
+        "loss.py",
+    ],
+    deps = [
+        ":operator",
+        "//src:utils",
+    ],
 )

--- a/src/operator/BUILD
+++ b/src/operator/BUILD
@@ -1,0 +1,30 @@
+package(default_visibility = ["//visibility:public"])
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "operator",
+    srcs = [
+        "operator.py",
+    ],
+)
+
+py_library(
+    name = "common",
+    srcs = [
+        "common.py",
+    ],
+    deps = [
+        ":operator",
+        "//src:utils",
+    ]
+)
+
+py_library(
+    name = "activation",
+    srcs = [
+        "activation.py",
+    ],
+    deps = [
+        ":operator"
+    ]
+)

--- a/src/operator/activation.py
+++ b/src/operator/activation.py
@@ -10,12 +10,12 @@ class BroadcastOperator(Operator):
     def __init__(self):
         super().__init__([], [])
 
-    def register(self, pred: Operator):
+    def add_pred(self, pred: Operator):
         if len(self.preds) == 1:
             raise Exception('Multiple input not supported for broadcat operator')
         # pass the input shape as output shape
         self.oshape = pred.oshape
-        return super().register(pred)
+        return super().add_pred(pred)
 
     def _eval(self, x: np.ndarray) -> np.ndarray:
         raise NotImplemented('_eval')

--- a/src/operator/activation.py
+++ b/src/operator/activation.py
@@ -1,0 +1,67 @@
+import numpy as np
+
+from src.operator.operator import Operator
+
+SIGMOID_INPUT_CAP = 700.
+
+
+class Activation(Operator):
+
+    def __init__(self):
+        super().__init__([], [])
+
+    def register(self, pred: Operator):
+        if len(self.preds) == 1:
+            raise Exception('Multiple input not supported for Activations')
+        # pass the input shape as output shape
+        self.oshape = pred.oshape
+        return super().register(pred)
+
+    def _eval(self, x: np.ndarray) -> np.ndarray:
+        raise NotImplemented('_eval')
+
+    def _grad(self, x: np.ndarray) -> np.ndarray:
+        raise NotImplemented('_grad')
+
+    def _forward_pass(self):
+        self.output = self._eval(self.preds[0].output)
+        super()._forward_pass()
+
+    def _back_prop(self):
+        dL_do = self._aggregate_grad()
+        do_dh = self._grad(self.output)
+        self.grad = dL_do * do_dh
+        super()._back_prop()
+
+
+class Sigmoid(Activation):
+
+    def _eval(self, x: np.ndarray) -> np.ndarray:
+        return 1. / (1. + np.exp(np.clip(-x, -SIGMOID_INPUT_CAP, SIGMOID_INPUT_CAP)))
+
+    def _grad(self, x: np.ndarray) -> np.ndarray:
+        return self._eval(x) * (1. - self._eval(x))
+
+
+class Identity(Activation):
+
+    @classmethod
+    def eval(cls, x: np.ndarray) -> np.ndarray:
+        return x
+
+    @classmethod
+    def grad(cls, x: np.ndarray) -> np.ndarray:
+        return 1.
+
+
+class ReLU(Activation):
+
+    @classmethod
+    def eval(cls, x: np.ndarray) -> np.ndarray:
+        rtn = x.copy()
+        rtn[x < 0.] = 0.
+        return rtn
+
+    @classmethod
+    def grad(cls, x: np.ndarray) -> np.ndarray:
+        return (x > 0).astype('float')

--- a/src/operator/activation.py
+++ b/src/operator/activation.py
@@ -5,14 +5,14 @@ from src.operator.operator import Operator
 SIGMOID_INPUT_CAP = 700.
 
 
-class Activation(Operator):
+class BroadcastOperator(Operator):
 
     def __init__(self):
         super().__init__([], [])
 
     def register(self, pred: Operator):
         if len(self.preds) == 1:
-            raise Exception('Multiple input not supported for Activations')
+            raise Exception('Multiple input not supported for broadcat operator')
         # pass the input shape as output shape
         self.oshape = pred.oshape
         return super().register(pred)
@@ -34,7 +34,7 @@ class Activation(Operator):
         super()._back_prop()
 
 
-class Sigmoid(Activation):
+class Sigmoid(BroadcastOperator):
 
     def _eval(self, x: np.ndarray) -> np.ndarray:
         return 1. / (1. + np.exp(np.clip(-x, -SIGMOID_INPUT_CAP, SIGMOID_INPUT_CAP)))
@@ -43,7 +43,7 @@ class Sigmoid(Activation):
         return self._eval(x) * (1. - self._eval(x))
 
 
-class Identity(Activation):
+class Identity(BroadcastOperator):
 
     @classmethod
     def eval(cls, x: np.ndarray) -> np.ndarray:
@@ -54,7 +54,7 @@ class Identity(Activation):
         return 1.
 
 
-class ReLU(Activation):
+class ReLU(BroadcastOperator):
 
     @classmethod
     def eval(cls, x: np.ndarray) -> np.ndarray:

--- a/src/operator/activation.py
+++ b/src/operator/activation.py
@@ -45,23 +45,19 @@ class Sigmoid(BroadcastOperator):
 
 class Identity(BroadcastOperator):
 
-    @classmethod
-    def eval(cls, x: np.ndarray) -> np.ndarray:
+    def _eval(cls, x: np.ndarray) -> np.ndarray:
         return x
 
-    @classmethod
-    def grad(cls, x: np.ndarray) -> np.ndarray:
+    def _grad(cls, x: np.ndarray) -> np.ndarray:
         return 1.
 
 
 class ReLU(BroadcastOperator):
 
-    @classmethod
-    def eval(cls, x: np.ndarray) -> np.ndarray:
+    def _eval(cls, x: np.ndarray) -> np.ndarray:
         rtn = x.copy()
         rtn[x < 0.] = 0.
         return rtn
 
-    @classmethod
-    def grad(cls, x: np.ndarray) -> np.ndarray:
+    def _grad(cls, x: np.ndarray) -> np.ndarray:
         return (x > 0).astype('float')

--- a/src/operator/activation.py
+++ b/src/operator/activation.py
@@ -29,7 +29,7 @@ class BroadcastOperator(Operator):
 
     def _back_prop(self):
         dL_do = self._aggregate_grad()
-        do_dh = self._grad(self.output)
+        do_dh = self._grad(self.preds[0].output)
         self.grad = dL_do * do_dh
         super()._back_prop()
 

--- a/src/operator/common.py
+++ b/src/operator/common.py
@@ -25,8 +25,8 @@ class MatMul(ParameterizedOperator):
     def _back_prop(self):
         dL_do = self._aggregate_grad()
         dL_dw = np.einsum('ki,kj', self.preds[0].output, dL_do)
-        self._w -= self._rate * dL_dw
         self.grad = np.einsum('ik,jk', dL_do, self._w)
+        self._w -= self._rate * dL_dw
         super()._back_prop()
 
 
@@ -49,7 +49,7 @@ class Bias(ParameterizedOperator):
 
     def _back_prop(self):
         dL_do = self._aggregate_grad()
-        dL_db = np.sum(dL_do, acis=0)
+        dL_db = np.sum(dL_do, axis=0)
         self._b -= self._rate * dL_db
         self.grad = dL_do
         super()._back_prop()

--- a/src/operator/common.py
+++ b/src/operator/common.py
@@ -5,18 +5,18 @@ from src.operator.operator import Operator, ParameterizedOperator
 from src.utils import check_shape
 
 
-class MatMul(ParameterizedOperator):
+class Linear(ParameterizedOperator):
     
     def __init__(self, ishape: List[int], oshape: List[int]):
         super().__init__(ishape, oshape)
         # weights initialized to [-0.1, 0.1]
         self._w = np.random.random((ishape[0], oshape[0])) / 5. - .1
 
-    def register(self, pred: Operator):
+    def add_pred(self, pred: Operator):
         if len(self.preds) == 1:
-            raise Exception('Multiple input not supported for MatMul')
+            raise Exception('Multiple input not supported for Linear')
         check_shape(pred.oshape, self.ishape)
-        super().register(pred)
+        super().add_pred(pred)
 
     def _forward_pass(self):
         self.output = np.matmul(self.preds[0].output, self._w)
@@ -37,11 +37,11 @@ class Bias(ParameterizedOperator):
         # bias initialized to 0.1
         self._b = np.ones(ishape) * .1
 
-    def register(self, pred: Operator):
+    def add_pred(self, pred: Operator):
         if len(self.preds) == 1:
             raise Exception('Multiple input not supported for bias')
         check_shape(pred.oshape, self.ishape)
-        super().register(pred)
+        super().add_pred(pred)
 
     def _forward_pass(self):
         self.output = self.preds[0].output + self._b

--- a/src/operator/common.py
+++ b/src/operator/common.py
@@ -1,0 +1,55 @@
+import numpy as np
+
+from typing import List
+from src.operator.operator import Operator, ParameterizedOperator
+from src.utils import check_shape
+
+
+class MatMul(ParameterizedOperator):
+    
+    def __init__(self, ishape: List[int], oshape: List[int]):
+        super().__init__(ishape, oshape)
+        # weights initialized to [-0.1, 0.1]
+        self._w = np.random.random((ishape[0], oshape[0])) / 5. - .1
+
+    def register(self, pred: Operator):
+        if len(self.preds) == 1:
+            raise Exception('Multiple input not supported for MatMul')
+        check_shape(pred.oshape, self.ishape)
+        super().register(pred)
+
+    def _forward_pass(self):
+        self.output = np.matmul(self.preds[0].output, self._w)
+        super()._forward_pass()
+
+    def _back_prop(self):
+        dL_do = self._aggregate_grad()
+        dL_dw = np.einsum('ki,kj', self.preds[0].output, dL_do)
+        self._w -= self._rate * dL_dw
+        self.grad = np.einsum('ik,jk', dL_do, self._w)
+        super()._back_prop()
+
+
+class Bias(ParameterizedOperator):
+
+    def __init__(self, ishape: List[int], oshape: List[int]):
+        super().__init__(ishape, oshape)
+        # bias initialized to 0.1
+        self._b = np.ones(ishape) * .1
+
+    def register(self, pred: Operator):
+        if len(self.preds) == 1:
+            raise Exception('Multiple input not supported for bias')
+        check_shape(pred.oshape, self.ishape)
+        super().register(pred)
+
+    def _forward_pass(self):
+        self.output = self.preds[0].output + self._b
+        super()._forward_pass()
+
+    def _back_prop(self):
+        dL_do = self._aggregate_grad()
+        dL_db = np.sum(dL_do, acis=0)
+        self._b -= self._rate * dL_db
+        self.grad = dL_do
+        super()._back_prop()

--- a/src/operator/loss.py
+++ b/src/operator/loss.py
@@ -1,0 +1,54 @@
+import numpy as np
+
+from typing import List
+from src.operator.operator import Operator
+from src.utils import check_shape
+
+
+class Loss(Operator):
+
+    def __init__(self, ishape: List[int]):
+        super().__init__(ishape, [])
+        self.preds = [None, None]
+
+    def register(self, pred: Operator):
+        raise NotImplemented(
+            'Regular register not supported for loss function, ' +
+            'use register_output and register_ground_truth')
+
+    def register_output(self, pred: Operator):
+        if self.preds[0] is not None:
+            raise Exception('Output for loss is already set')
+        check_shape(self.ishape, pred.oshape)
+        self.preds[0] = pred
+        pred.succs.append(self)
+
+    def register_ground_truth(self, pred: Operator):
+        if self.preds[1] is not None:
+            raise Exception('Ground truth for loss is already set')
+        check_shape(self.ishape, pred.oshape)
+        self.preds[1] = pred
+        pred.succs.append(self)
+
+    @property
+    def y(self):
+        return self.preds[0].output
+
+    @property
+    def gt(self):
+        return self.preds[1].output
+
+
+class MSE(Loss):
+
+    def _forward_pass(self):
+        if self.y.shape != self.gt.shape:
+            raise ValueError('Model output and ground truth have different shape')
+        self.output = ((self.gt - self.y) ** 2).sum()
+        # super()._forward_pass()
+
+    def _back_prop(self):
+        if self.y.shape != self.gt.shape:
+            raise ValueError('Model output and ground truth have different shape')
+        self.grad = 2 * (self.gt - self.y)
+        super()._back_prop()

--- a/src/operator/loss.py
+++ b/src/operator/loss.py
@@ -44,11 +44,11 @@ class MSE(Loss):
     def _forward_pass(self):
         if self.y.shape != self.gt.shape:
             raise ValueError('Model output and ground truth have different shape')
-        self.output = ((self.gt - self.y) ** 2).sum()
+        self.output = ((self.y - self.gt) ** 2).sum()
         # super()._forward_pass()
 
     def _back_prop(self):
         if self.y.shape != self.gt.shape:
             raise ValueError('Model output and ground truth have different shape')
-        self.grad = 2 * (self.gt - self.y)
+        self.grad = 2 * (self.y - self.gt)
         super()._back_prop()

--- a/src/operator/loss.py
+++ b/src/operator/loss.py
@@ -12,19 +12,19 @@ class Loss(Operator):
         super().__init__(ishape, [])
         self.preds = [None, None]
 
-    def register(self, pred: Operator):
+    def add_pred(self, pred: Operator):
         raise NotImplemented(
-            'Regular register not supported for loss function, ' +
-            'use register_output and register_ground_truth')
+            'Regular add_pred not supported for loss function, ' +
+            'use add_output and add_ground_truth')
 
-    def register_output(self, pred: Operator):
+    def add_output(self, pred: Operator):
         if self.preds[0] is not None:
             raise Exception('Output for loss is already set')
         check_shape(self.ishape, pred.oshape)
         self.preds[0] = pred
         pred.succs.append(self)
 
-    def register_ground_truth(self, pred: Operator):
+    def add_ground_truth(self, pred: Operator):
         if self.preds[1] is not None:
             raise Exception('Ground truth for loss is already set')
         check_shape(self.ishape, pred.oshape)
@@ -32,7 +32,7 @@ class Loss(Operator):
         pred.succs.append(self)
 
     @property
-    def y(self):
+    def y_pred(self):
         return self.preds[0].output
 
     @property
@@ -40,7 +40,7 @@ class Loss(Operator):
         return self.preds[1].output
 
     def _check_output_shape(self):
-        if self.y.shape != self.gt.shape:
+        if self.y_pred.shape != self.gt.shape:
             raise ValueError('Model output and ground truth have different shape')
 
 
@@ -48,12 +48,12 @@ class MSE(Loss):
 
     def _forward_pass(self):
         self._check_output_shape()
-        self.output = ((self.y - self.gt) ** 2).sum()
+        self.output = ((self.y_pred - self.gt) ** 2).sum()
         # super()._forward_pass()
 
     def _back_prop(self):
         self._check_output_shape()
-        self.grad = 2 * (self.y - self.gt)
+        self.grad = 2 * (self.y_pred - self.gt)
         super()._back_prop()
 
 
@@ -61,11 +61,11 @@ class CrossEntropy(Loss):
 
     def _forward_pass(self):
         self._check_output_shape()
-        self.output = -(self.gt * np.log(self.y)).sum() / self.y.shape[1]
+        self.output = -(self.gt * np.log(self.y_pred)).sum() / self.y_pred.shape[1]
 
     def _back_prop(self):
         self._check_output_shape()
-        self.grad = -(self.gt / self.y) / self.y.shape[1]
+        self.grad = -(self.gt / self.y_pred) / self.y_pred.shape[1]
         super()._back_prop()
 
 
@@ -73,10 +73,10 @@ class CrossEntropyWithSoftmax(Loss):
 
     def _forward_pass(self):
         self._check_output_shape()
-        p = Softmax()._eval(self.y)
-        self.output = -(self.gt * np.log(p)).sum() / self.y.shape[1]
+        p = Softmax()._eval(self.y_pred)
+        self.output = -(self.gt * np.log(p)).sum() / self.y_pred.shape[1]
 
     def _back_prop(self):
-        p = Softmax()._eval(self.y)
-        self.grad = (p - self.gt) / self.y.shape[1]
+        p = Softmax()._eval(self.y_pred)
+        self.grad = (p - self.gt) / self.y_pred.shape[1]
         super()._back_prop()

--- a/src/operator/loss.py
+++ b/src/operator/loss.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from typing import List
 from src.operator.operator import Operator
+from src.operator.normalizer import Softmax
 from src.utils import check_shape
 
 
@@ -38,17 +39,44 @@ class Loss(Operator):
     def gt(self):
         return self.preds[1].output
 
+    def _check_output_shape(self):
+        if self.y.shape != self.gt.shape:
+            raise ValueError('Model output and ground truth have different shape')
+
 
 class MSE(Loss):
 
     def _forward_pass(self):
-        if self.y.shape != self.gt.shape:
-            raise ValueError('Model output and ground truth have different shape')
+        self._check_output_shape()
         self.output = ((self.y - self.gt) ** 2).sum()
         # super()._forward_pass()
 
     def _back_prop(self):
-        if self.y.shape != self.gt.shape:
-            raise ValueError('Model output and ground truth have different shape')
+        self._check_output_shape()
         self.grad = 2 * (self.y - self.gt)
+        super()._back_prop()
+
+
+class CrossEntropy(Loss):
+
+    def _forward_pass(self):
+        self._check_output_shape()
+        self.output = -(self.gt * np.log(self.y)).sum() / self.y.shape[1]
+
+    def _back_prop(self):
+        self._check_output_shape()
+        self.grad = -(self.gt / self.y) / self.y.shape[1]
+        super()._back_prop()
+
+
+class CrossEntropyWithSoftmax(Loss):
+
+    def _forward_pass(self):
+        self._check_output_shape()
+        p = Softmax()._eval(self.y)
+        self.output = -(self.gt * np.log(p)).sum() / self.y.shape[1]
+
+    def _back_prop(self):
+        p = Softmax()._eval(self.y)
+        self.grad = (p - self.gt) / self.y.shape[1]
         super()._back_prop()

--- a/src/operator/normalizer.py
+++ b/src/operator/normalizer.py
@@ -49,4 +49,3 @@ class Softmax(Normalizer):
         do_dx = o_kd_tensor - oij_tensor
         self.grad = np.sum(dL_do.reshape((n, m, 1)) * do_dx, axis=1) # dL_dx
         super()._back_prop()
-        

--- a/src/operator/normalizer.py
+++ b/src/operator/normalizer.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+from src.operator.operator import Operator
+
+class Normalizer(Operator):
+
+    def __init__(self):
+        super().__init__([], [])
+
+    def register(self, pred: Operator):
+        if len(self.preds) == 1:
+            raise Exception('Multiple input not supported for normalizer')
+        # pass the input shape as output shape
+        self.oshape = pred.oshape
+        return super().register(pred)
+
+    def _eval(self, x: np.ndarray) -> np.ndarray:
+        raise NotImplemented('_eval')
+
+    def _forward_pass(self):
+        self.output = self._eval(self.preds[0].output)
+        super()._forward_pass()
+
+
+class Softmax(Normalizer):
+
+    def register(self, pred: Operator):
+        if len(pred.oshape) > 1:
+            raise ValueError('Multi-dimensional input not supported for softmax')
+        super().register(pred)
+
+    def _eval(self, x: np.ndarray) -> np.ndarray:
+        exp = np.exp(x)
+        return exp / exp.sum(axis=1)[:, np.newaxis]
+
+    def _back_prop(self):
+        n, m = self.output.shape
+        dL_do = self._aggregate_grad()
+        # do_j/dx_i = o_i * (δ_ij - o_j), δ is Kronecker delta
+        # dL/dx_i = ∑(dL/do_j * do_j/dx_i)
+        # do/dx is tensor over softmax
+        # tensor product of o
+        oij_tensor = np.einsum('...i,...j', self.output, self.output)
+        # TODO: is there any way to simplify the following part?
+        # kronecker delta tensor
+        kd_tensor = np.repeat(np.diag(np.ones((m))).reshape((1, m, m)), n, axis=0)
+        # o_i * δ_ij tensor
+        o_kd_tensor = np.repeat(self.output.reshape((n, m, 1)), m, axis=2) * kd_tensor
+        do_dx = o_kd_tensor - oij_tensor
+        self.grad = np.sum(dL_do.reshape((n, m, 1)) * do_dx, axis=1) # dL_dx
+        super()._back_prop()
+        

--- a/src/operator/normalizer.py
+++ b/src/operator/normalizer.py
@@ -7,12 +7,12 @@ class Normalizer(Operator):
     def __init__(self):
         super().__init__([], [])
 
-    def register(self, pred: Operator):
+    def add_pred(self, pred: Operator):
         if len(self.preds) == 1:
             raise Exception('Multiple input not supported for normalizer')
         # pass the input shape as output shape
         self.oshape = pred.oshape
-        return super().register(pred)
+        return super().add_pred(pred)
 
     def _eval(self, x: np.ndarray) -> np.ndarray:
         raise NotImplemented('_eval')
@@ -24,10 +24,10 @@ class Normalizer(Operator):
 
 class Softmax(Normalizer):
 
-    def register(self, pred: Operator):
+    def add_pred(self, pred: Operator):
         if len(pred.oshape) > 1:
             raise ValueError('Multi-dimensional input not supported for softmax')
-        super().register(pred)
+        super().add_pred(pred)
 
     def _eval(self, x: np.ndarray) -> np.ndarray:
         exp = np.exp(x)

--- a/src/operator/operator.py
+++ b/src/operator/operator.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from typing import List, Tuple
-from src.utils import check_shape
+from typing import List
 
 
 class Operator:
@@ -37,6 +36,10 @@ class Operator:
         self.preds.append(pred)
         pred.succs.append(self)
 
+    def _aggregate_grad(self) -> np.ndarray:
+        # sum up gradients from all successors for back prop
+        return np.sum(np.array([succ.grad for succ in self.succs]))
+
 
 class ParameterizedOperator(Operator):
 
@@ -45,26 +48,3 @@ class ParameterizedOperator(Operator):
     def __init__(self, ishape: List[int], oshape: List[int], rate: float = None):
         super().__init__(ishape, oshape)
         self._rate = rate if rate is not None else self.__class__.rate
-
-
-class MatMul(ParameterizedOperator):
-    
-    def __init__(self, ishape: List[int], oshape: List[int]):
-        super().__init__(ishape, oshape)
-        # weights initialized to [-0.1, 0.1]
-        self._w = np.random.random((ishape[0], oshape[0])) / 5. - .1
-
-    def register(self, pred: 'Operator'):
-        check_shape(pred.oshape, self.ishape)
-        super().register(pred)
-
-    def _forward_pass(self):
-        self.output = np.matmul(self.preds[0].output, self._w)
-        super()._forward_pass()
-
-    def _back_prop(self):
-        dL_do = np.sum(np.array([succ.grad for succ in self.succs]))
-        dL_dw = np.einsum('ki,kj', self.preds[0].output, dL_do)
-        self._w -= self._rate * dL_dw
-        self.grad = np.einsum('ik,jk', dL_do, self._w)
-        super()._back_prop()

--- a/src/operator/operator.py
+++ b/src/operator/operator.py
@@ -7,7 +7,7 @@ class Operator:
 
     def __init__(self, ishape: List[int], oshape: List[int]):
         self.ishape, self.oshape = tuple(ishape), tuple(oshape)
-        self.preds, self.succs= [], []
+        self.preds, self.succs = [], []
         self.forward_pass_count, self.back_prod_count = 0, 0
 
     def _forward_pass(self):

--- a/src/operator/operator.py
+++ b/src/operator/operator.py
@@ -32,7 +32,7 @@ class Operator:
             self._back_prop()
             self.back_prod_count = 0
 
-    def register(self, pred: 'Operator'):
+    def add_pred(self, pred: 'Operator'):
         self.preds.append(pred)
         pred.succs.append(self)
 

--- a/src/operator/operator.py
+++ b/src/operator/operator.py
@@ -38,7 +38,7 @@ class Operator:
 
     def _aggregate_grad(self) -> np.ndarray:
         # sum up gradients from all successors for back prop
-        return np.sum(np.array([succ.grad for succ in self.succs]))
+        return np.sum(np.array([succ.grad for succ in self.succs]), axis=0)
 
 
 class ParameterizedOperator(Operator):

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,13 +1,13 @@
 import numpy as np
 from typing import Tuple
 
-def check_shape(x: np.ndarray, expected_shape: Tuple[int, int], axis: int = None):
-    if axis is None and x.shape == expected_shape:
+def check_shape(x_shape: Tuple, expected_shape: Tuple, axis: int = None):
+    if axis is None and x_shape == expected_shape:
         return
-    if axis is not None and x.shape[axis] == expected_shape[axis]:
+    if axis is not None and x_shape[axis] == expected_shape[axis]:
         return
     raise Exception('tested shape {} does not match expected shape {}'.format(
-        x.shape, expected_shape))
+        x_shape, expected_shape))
 
 def print_progress_bar(percent: int, i: int, n: int) -> int:
     if i > percent * n / 100.:

--- a/test/BUILD
+++ b/test/BUILD
@@ -24,6 +24,7 @@ py_test(
         "//src/operator:activation",
         "//src/operator:common",
         "//src/operator:loss",
+        "//src/operator:normalizer",
         "//src/operator:operator",
     ],
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -23,6 +23,7 @@ py_test(
     deps = [
         "//src/operator:activation",
         "//src/operator:common",
+        "//src/operator:loss",
         "//src/operator:operator",
     ],
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -21,6 +21,8 @@ py_test(
     name = "operator_test",
     srcs = ["operator_test.py"],
     deps = [
-        "//src:nn_src",
+        "//src/operator:activation",
+        "//src/operator:common",
+        "//src/operator:operator",
     ],
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -16,3 +16,11 @@ py_test(
         "//src:nn_src",
     ],
 )
+
+py_test(
+    name = "operator_test",
+    srcs = ["operator_test.py"],
+    deps = [
+        "//src:nn_src",
+    ],
+)

--- a/test/operator_test.py
+++ b/test/operator_test.py
@@ -1,6 +1,9 @@
+import numpy as np
 import unittest
 
-from src.operator import Operator
+from src.operator.operator import Operator
+from src.operator.common import Bias, MatMul
+from src.operator.activation import Sigmoid
 
 
 class Plus(Operator):
@@ -17,7 +20,7 @@ class Plus(Operator):
 
 class OperatorTest(unittest.TestCase):
 
-    def test_forward_pass(self):
+    def test_forward_pass_topo_sort(self):
         expected_result = [0, 1, 2, 5, 9, 14, 23, 31, 53]
         a = [Plus(i) for i in range(9)]
         a[1].register(a[0])
@@ -39,6 +42,56 @@ class OperatorTest(unittest.TestCase):
         for i, x in enumerate(a):
             self.assertEqual(x.output, expected_result[i])
             self.assertEqual(x.forward_pass_count, 0)
+
+    def test_forward_pass(self):
+        # initialize
+        # _input - MatMul1 - Bias1 - Sigmoid1 - MatMul2 - Bias2 - Sigmoid2
+        _input = Operator([], [2])
+        _input.output = np.array([[.7, 2.]])
+        mm1 = MatMul([2], [3])
+        mm1._w = np.array(
+            [
+                [.1, 2, -.7],
+                [-5, .1, 1.5]
+            ]
+        )
+        mm1.register(_input)
+        b1 = Bias([3], [3])
+        b1._b = np.zeros(3)
+        b1.register(mm1)
+        a1 = Sigmoid()
+        a1.register(b1)
+        mm2 = MatMul([3], [2])
+        mm2._w = np.array(
+            [
+                [.3, -1.5],
+                [1, .2],
+                [.2, 3]
+            ]
+        )
+        mm2.register(a1)
+        b2 = Bias([2],[2])
+        b2._b = np.zeros(2)
+        b2.register(mm2)
+        a2 = Sigmoid()
+        a2.register(b2)
+
+        # forward pass
+        _input._forward_pass()
+
+        # check result
+        self.assertAlmostEqual(b1.output[0][0], -9.93)
+        self.assertAlmostEqual(b1.output[0][1], 1.6)
+        self.assertAlmostEqual(b1.output[0][2], 2.51)
+        self.assertAlmostEqual(a1.output[0][0], 4.8689425323061825e-05)
+        self.assertAlmostEqual(a1.output[0][1], 0.8320183851339245)
+        self.assertAlmostEqual(a1.output[0][2], 0.9248398905178734)
+        self.assertAlmostEqual(b2.output[0][0], 1.0170009700650962)
+        self.assertAlmostEqual(b2.output[0][1], 2.9408503144424207)
+        self.assertAlmostEqual(a2.output[0][0], 0.7343880132771364)
+        self.assertAlmostEqual(a2.output[0][1], 0.949829262885629)
+    
+    # TODO: add test_back_prop after cost operators are implemented
 
 
 if __name__ == '__main__':

--- a/test/operator_test.py
+++ b/test/operator_test.py
@@ -1,0 +1,50 @@
+import unittest
+
+from src.operator import Operator
+
+
+class Plus(Operator):
+
+    def __init__(self, p: int):
+        super().__init__()
+        self.p = p
+        self.output = None
+
+    def register(self, succ: Operator):
+        self.succs.append(succ)
+        succ.preds.append(self)
+
+    def _forward_pass(self):
+        self.output = sum(pred.output for pred in self.preds) + self.p
+        for succ in self.succs:
+            succ.forward_pass()
+
+
+class OperatorTest(unittest.TestCase):
+
+    def test_forward_pass(self):
+        expected_result = [0, 1, 2, 5, 9, 14, 23, 31, 53]
+        a = [Plus(i) for i in range(9)]
+        a[0].register(a[1])
+        a[0].register(a[2])
+        a[1].register(a[6])
+        a[1].register(a[7])
+        a[2].register(a[6])
+        a[2].register(a[3])
+        a[3].register(a[6])
+        a[3].register(a[4])
+        a[4].register(a[6])
+        a[4].register(a[5])
+        a[5].register(a[8])
+        a[6].register(a[7])
+        a[7].register(a[8])
+        a[0].output = 0
+        for succ in a[0].succs:
+            succ.forward_pass()
+        for i, x in enumerate(a):
+            self.assertEqual(x.output, expected_result[i])
+            self.assertEqual(x.forward_pass_count, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/operator_test.py
+++ b/test/operator_test.py
@@ -6,18 +6,13 @@ from src.operator import Operator
 class Plus(Operator):
 
     def __init__(self, p: int):
-        super().__init__()
+        super().__init__([0], [0])
         self.p = p
         self.output = None
 
-    def register(self, succ: Operator):
-        self.succs.append(succ)
-        succ.preds.append(self)
-
     def _forward_pass(self):
         self.output = sum(pred.output for pred in self.preds) + self.p
-        for succ in self.succs:
-            succ.forward_pass()
+        super()._forward_pass()
 
 
 class OperatorTest(unittest.TestCase):
@@ -25,19 +20,19 @@ class OperatorTest(unittest.TestCase):
     def test_forward_pass(self):
         expected_result = [0, 1, 2, 5, 9, 14, 23, 31, 53]
         a = [Plus(i) for i in range(9)]
-        a[0].register(a[1])
-        a[0].register(a[2])
-        a[1].register(a[6])
-        a[1].register(a[7])
-        a[2].register(a[6])
-        a[2].register(a[3])
-        a[3].register(a[6])
-        a[3].register(a[4])
-        a[4].register(a[6])
-        a[4].register(a[5])
-        a[5].register(a[8])
-        a[6].register(a[7])
-        a[7].register(a[8])
+        a[1].register(a[0])
+        a[2].register(a[0])
+        a[6].register(a[1])
+        a[7].register(a[1])
+        a[6].register(a[2])
+        a[3].register(a[2])
+        a[6].register(a[3])
+        a[4].register(a[3])
+        a[6].register(a[4])
+        a[5].register(a[4])
+        a[8].register(a[5])
+        a[7].register(a[6])
+        a[8].register(a[7])
         a[0].output = 0
         for succ in a[0].succs:
             succ.forward_pass()


### PR DESCRIPTION
Refactor Existing components into operators to enable more flexible network structure and computation graph. Did some intense OOD but the basic idea is as follows:
- Base `Operator` class supports:
    - input/output shape: `ishape` and `oshape`
    - predecessors and successors for connecting operators to form graph: `preds` and `succs`
    - Pred and succ counter for topological order forward pass and back prop.
- `ParameterizedOperator` for operators with parameters to be trained (`MatMul`, `Bias`), which support an extra learning rate attribute `rate` which can be tuned per operator or globally.
- `BroadcastOperator` for operators with following property (basically all common activations functions):
    - Doesn't care about input shape and will output the same shape as input
    - Basically does something to a single element, that will be broadcasted to the whole input
- `Normalizer` for normalizing operators like `Softmax` and `BN` (not supported in this PR)
- `Loss` for loss functions (`MSE`, `CrossEntropy`, `CrossEntropyWithSoftmax`):
    - Only allowed as the end of graph (no successors)
    - Only 2 inputs are allowed: model output and ground truth

Please refer to `operator_test` for some example graph constructed with operators. I know this is a huge change, so please feel free to leave any comments.

Followups:
- Better approach for getting grad for Softmax?
- Add `Input` and `GroundTruth` operator
- Add training support and integrate with or refactor model/layer
- Benchmark solutions before/after refactor