### PR TITLE
Fix self-hosted actions runner restart issue

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -18,6 +18,8 @@ USER actions-runner
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+COPY main.sh /home/actions-runner/main.sh
+
 WORKDIR /home/actions-runner
 
-ENTRYPOINT ./config.sh --url https://github.com/KevinXuxuxu/NN --token $TOKEN && ./run.sh
+ENTRYPOINT ./main.sh

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -1,0 +1,4 @@
+./config.sh --url https://github.com/KevinXuxuxu/NN --token $TOKEN
+./run.sh &
+wait
+sleep infinity


### PR DESCRIPTION
In the previous solution, actions runner runs as the main process of docker container, and if it update version and restarts (something I didn't know before), the container is terminated.

To resolve this, a shell script is added and actions runner is running in the background with a sleeping main process to make sure it doesn't terminate the container.

This version is working in production.