### PR TITLE
Migrate ci image to be arch aware

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM fzxu/nn
+FROM fzxu/nn_x86_64
 
 RUN adduser --disabled-password --gecos "" actions-runner
 
@@ -17,6 +17,8 @@ RUN cd /home/actions-runner && ./bin/installdependencies.sh
 USER actions-runner
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+ENV PATH=$PATH:/srv/miniconda/bin
 
 COPY main.sh /home/actions-runner/main.sh
 

--- a/ci/Dockerfile_amd64
+++ b/ci/Dockerfile_amd64
@@ -1,4 +1,4 @@
-FROM fzxu/nn_x86_64
+FROM fzxu/nn
 
 RUN adduser --disabled-password --gecos "" actions-runner
 

--- a/ci/Dockerfile_arm64
+++ b/ci/Dockerfile_arm64
@@ -1,0 +1,27 @@
+FROM fzxu/nn
+
+RUN adduser --disabled-password --gecos "" actions-runner
+
+USER actions-runner
+
+RUN cd /home/actions-runner \
+  && curl -o actions-runner-linux-arm64-2.285.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.285.0/actions-runner-linux-arm64-2.285.0.tar.gz \
+  && tar xzf ./actions-runner-linux-arm64-2.285.0.tar.gz
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN cd /home/actions-runner && ./bin/installdependencies.sh
+
+USER actions-runner
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV PATH=$PATH:/srv/miniconda/bin
+
+COPY main.sh /home/actions-runner/main.sh
+
+WORKDIR /home/actions-runner
+
+ENTRYPOINT ./main.sh


### PR DESCRIPTION
Rebuild the github actions runner image based on new x86_64 nn image. (per change in https://github.com/KevinXuxuxu/NN/pull/17)

Add `/srv/miniconda/bin` to `PATH` to make python related things available.